### PR TITLE
ci: add production CI/CD workflow

### DIFF
--- a/.github/instructions/deployment.instructions.md
+++ b/.github/instructions/deployment.instructions.md
@@ -29,11 +29,15 @@ Sygnal runs as a **Docker container on the Synapse EC2 instances**, managed by t
 
 | Component | Detail |
 |-----------|--------|
-| **Docker image** | `localhost/pangeachat/sygnal:main` — built directly on the EC2 instance |
-| **CI/CD** | **None.** Manual SSH + docker build + systemd restart. |
+| **Docker image** | `061565848348.dkr.ecr.us-east-1.amazonaws.com/pangea-prod-sygnal:production` |
+| **CI/CD** | `.github/workflows/deploy-production.yml` — push to `production` branch → ECR build → SSM deploy |
+| **IAM (push)** | `github-deploy-prod` OIDC role — ECR push + SSM RunCommand |
+| **IAM (pull)** | `CloudWatchAgentServerRole` — `ecr-pull-prod` inline policy (Terraform: `prod/iam/ec2-ecr-pull`) |
 | **Ansible vars** | [`ansible/inventory/production/host_vars/matrix.pangea.chat/vars.yml`](../../ansible/inventory/production/host_vars/matrix.pangea.chat/vars.yml) |
+| **EC2 instance** | `i-074c64998e68a5bc6` (`52.203.29.202`) |
 | **Reverse proxy** | Traefik — routes `sygnal.pangea.chat` → container port 6000 |
 | **DNS** | CNAME `sygnal.pangea.chat` → `matrix.pangea.chat` (Route 53, not yet in Terraform) |
+| **ECR repo** | Terraform: `prod/ecr/sygnal` |
 | **Systemd service** | `matrix-sygnal` |
 
 ## Staging Deploys (CI/CD)
@@ -42,27 +46,30 @@ Every push to `main` triggers the deploy workflow:
 
 1. **Build & push** — Docker Buildx builds `linux/amd64` image, pushes to ECR with `:main` and `:${SHA}` tags
 2. **Deploy** — OIDC auth → SSM RunCommand on staging EC2:
-   - `aws ecr get-login-password | docker login` (ECR auth on-instance)
-   - `docker pull` the new image
+   - `docker pull` the new image (ECR auth via `amazon-ecr-credential-helper`)
    - `systemctl restart matrix-sygnal`
    - Health check via `systemctl is-active`
 
+## Production Deploys (CI/CD)
+
+Every push to `production` triggers the deploy workflow:
+
+1. **Build & push** — Docker Buildx builds `linux/amd64` image, pushes to ECR with `:production` and `:${SHA}` tags
+2. **Deploy** — OIDC auth → SSM RunCommand on production EC2:
+   - `docker pull` the new image (ECR auth via `amazon-ecr-credential-helper`)
+   - `systemctl restart matrix-sygnal`
+   - Health check via `systemctl is-active`
+
+To deploy: merge `main` → `production` (or push directly to `production`).
+
 ### Bootstrap (First-Time Setup)
 
-Before CI/CD can deploy, Ansible must bootstrap the Sygnal container and Traefik route:
+Before CI/CD can deploy, Ansible must bootstrap the Sygnal container, ECR credential helper, and Traefik route:
 
 ```bash
 # Push an initial image to ECR first (or run the workflow once to populate it)
-ansible-playbook -i inventory/staging/hosts setup.yml --tags=setup-sygnal,start
+ansible-playbook -i inventory/<env>/hosts setup.yml --tags=setup-sygnal,start
 ```
-
-## Production Deploys (Manual)
-
-1. **SSH into production**: `ssh ubuntu@52.203.29.202`
-2. **Pull latest code**: `cd /path/to/sygnal && git pull origin main`
-3. **Rebuild**: `docker build -f docker/Dockerfile -t localhost/pangeachat/sygnal:main .`
-4. **Restart**: `sudo systemctl restart matrix-sygnal`
-5. **Verify**: `sudo journalctl -fu matrix-sygnal`
 
 ### Config-Only Changes
 
@@ -74,14 +81,16 @@ ansible-playbook -i inventory/<env>/hosts setup.yml --tags=setup-sygnal,start
 
 ## Infrastructure (Terraform)
 
-All staging infrastructure is managed in `devops/terraform/staging/`:
+Managed in `devops/terraform/{staging,prod}/`:
 
-| Resource | Terragrunt path |
-|----------|----------------|
-| ECR repository | `ecr/sygnal/` |
-| DNS CNAME | `dns/sygnal/` |
-| OIDC role (ECR push + SSM) | `iam/github-oidc/` |
-| EC2 ECR pull policy | `iam/ec2-ecr-pull/` |
+| Resource | Staging | Production |
+|----------|---------|------------|
+| ECR repository | `staging/ecr/sygnal/` | `prod/ecr/sygnal/` |
+| DNS CNAME | `staging/dns/sygnal/` | Not yet in Terraform |
+| OIDC role (ECR push + SSM) | `staging/iam/github-oidc/` | `prod/iam/github-oidc/` |
+| EC2 ECR pull policy | `staging/iam/ec2-ecr-pull/` | `prod/iam/ec2-ecr-pull/` |
+
+**Note:** Both envs share a single `CloudWatchAgentServerRole` IAM role (created outside Terraform). The ECR pull policies are named `ecr-pull` (staging) and `ecr-pull-prod` (production) to avoid collision. The OIDC provider is created by staging; production references it via data source (`create_oidc_provider = false`).
 
 ## Client Integration
 
@@ -95,5 +104,4 @@ The client registers a pusher with Synapse via `POST /_matrix/client/v3/pushers/
 
 ## Future Work
 
-- Add CI/CD for production (mirror the staging pattern with a `pangea-prod-sygnal` ECR repo)
 - Move production DNS CNAME into Terraform

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,119 @@
+name: Deploy to Production
+
+on:
+  push:
+    branches: [production]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write # Required for OIDC
+
+env:
+  ECR_REGISTRY: 061565848348.dkr.ecr.us-east-1.amazonaws.com
+  ECR_REPOSITORY: pangea-prod-sygnal
+  INSTANCE_ID: i-074c64998e68a5bc6
+  AWS_REGION: us-east-1
+  IAM_ROLE: arn:aws:iam::061565848348:role/github-deploy-prod
+
+jobs:
+  build-and-push:
+    name: Build & Push Docker Image
+    runs-on: ubuntu-latest
+    outputs:
+      image-tag: ${{ steps.build-image.outputs.image-tag }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.IAM_ROLE }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        id: build-image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile
+          push: true
+          platforms: linux/amd64
+          tags: |
+            ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:production
+            ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=min
+
+      - name: Output image tag
+        run: echo "image-tag=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+
+  deploy:
+    name: Deploy to Production EC2
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.IAM_ROLE }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Deploy via SSM
+        id: ssm-command
+        run: |
+          IMAGE="${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:production"
+          COMMAND_ID=$(aws ssm send-command \
+            --instance-ids "${{ env.INSTANCE_ID }}" \
+            --document-name "AWS-RunShellScript" \
+            --parameters "commands=[
+              \"bash -c 'set -euo pipefail && echo Pulling ${IMAGE} && docker pull ${IMAGE} && echo Restarting matrix-sygnal && systemctl restart matrix-sygnal && sleep 5 && systemctl is-active matrix-sygnal && echo Deploy complete'\"
+            ]" \
+            --timeout-seconds 300 \
+            --comment "Sygnal production deploy from ${{ github.sha }}" \
+            --query 'Command.CommandId' \
+            --output text)
+          echo "command-id=$COMMAND_ID" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for deploy completion
+        run: |
+          COMMAND_ID="${{ steps.ssm-command.outputs.command-id }}"
+          echo "Waiting for SSM command $COMMAND_ID ..."
+
+          for i in $(seq 1 36); do
+            STATUS=$(aws ssm get-command-invocation \
+              --command-id "$COMMAND_ID" \
+              --instance-id "${{ env.INSTANCE_ID }}" \
+              --query 'Status' \
+              --output text 2>/dev/null || echo "Pending")
+
+            echo "  Attempt $i: $STATUS"
+            if [[ "$STATUS" == "Success" ]]; then
+              echo "Deploy succeeded."
+              aws ssm get-command-invocation \
+                --command-id "$COMMAND_ID" \
+                --instance-id "${{ env.INSTANCE_ID }}" \
+                --query 'StandardOutputContent' \
+                --output text
+              exit 0
+            elif [[ "$STATUS" == "Failed" || "$STATUS" == "Cancelled" || "$STATUS" == "TimedOut" ]]; then
+              echo "Deploy failed with status: $STATUS"
+              aws ssm get-command-invocation \
+                --command-id "$COMMAND_ID" \
+                --instance-id "${{ env.INSTANCE_ID }}" \
+                --query '[StandardOutputContent, StandardErrorContent]' \
+                --output text
+              exit 1
+            fi
+            sleep 5
+          done
+          echo "Timed out waiting for SSM command."
+          exit 1


### PR DESCRIPTION
## What

Production CI/CD workflow + updated deployment docs for Sygnal.

## Why

Closes #3

## Changes

- `deploy-production.yml`: push to `production` branch triggers ECR build + SSM deploy to production EC2
- `deployment.instructions.md`: updated with production CI/CD architecture, bootstrap steps, infrastructure table

## Testing

Will be tested end-to-end when the `production` branch is first created and pushed.

- [ ] Staging
- [ ] Production

## Deploy Notes

Cross-repo dependency — merge these PRs first:
1. pangeachat/devops#50 (prod ECR + OIDC + ec2-ecr-pull — already applied)
2. pangeachat/synapse sygnal-prod-ecr branch (Ansible vars: switch prod to ECR image)
3. Run Ansible bootstrap on prod: `ansible-playbook -i inventory/production/hosts setup.yml --tags=setup-sygnal,start`
4. Then merge this PR and push to `production` branch to trigger first deploy
