### PR TITLE
ci: pin all GitHub Actions to SHA hashes, add permissions blocks

### DIFF
--- a/.github/workflows/changelog_check.yml
+++ b/.github/workflows/changelog_check.yml
@@ -1,16 +1,19 @@
 name: Changelog
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   check-newsfile:
     if: ${{ github.base_ref == 'main'  || contains(github.base_ref, 'release-') }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           fetch-depth: 0
           ref: ${{github.event.pull_request.head.sha}}
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
         with:
           python-version: "3.11"
       - run: python -m pip install towncrier

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -24,24 +24,24 @@ jobs:
       image-tag: ${{ steps.build-image.outputs.image-tag }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: ${{ env.IAM_ROLE }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Build and push
         id: build-image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: docker/Dockerfile
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: ${{ env.IAM_ROLE }}
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -24,24 +24,24 @@ jobs:
       image-tag: ${{ steps.build-image.outputs.image-tag }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: ${{ env.IAM_ROLE }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Build and push
         id: build-image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: docker/Dockerfile
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: ${{ env.IAM_ROLE }}
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/docker_check.yml
+++ b/.github/workflows/docker_check.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - name: Set up QEMU
         id: qemu
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480 # v1
         with:
           platforms: arm64
 
@@ -43,7 +43,7 @@ jobs:
       # otherwise we can't export the multi-arch image later
       # https://github.com/docker/buildx/issues/59#issuecomment-2770311050
       - name: Set up Docker
-        uses: docker/setup-docker-action@v4
+        uses: docker/setup-docker-action@e43656e248c0bd0647d3f5c195d116aacf6fcaf4 # v4
         with:
           daemon-config: |
             {
@@ -54,7 +54,7 @@ jobs:
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9 # v1
 
       - name: Inspect builder
         run: docker buildx inspect
@@ -64,10 +64,10 @@ jobs:
       # (part of build system config in pyproject.toml) can deduce the package version.
       # See: https://github.com/marketplace/actions/build-and-push-docker-images#path-context
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Build all platforms
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           push: false
@@ -86,7 +86,7 @@ jobs:
 
       # https://docs.docker.com/build/ci/github-actions/share-image-jobs/
       - name: Upload container image for subsequent steps
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: sygnal_image
           path: ${{ runner.temp }}/sygnal_image.tar
@@ -98,7 +98,7 @@ jobs:
     needs: build
     steps:
       - name: Download container image from build step
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: sygnal_image
           path: ${{ runner.temp }}
@@ -107,7 +107,7 @@ jobs:
         run: |
           docker image load --input ${{ runner.temp }}/sygnal_image.tar
 
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Prepare test setup
         run: |
@@ -153,7 +153,7 @@ jobs:
 
       - name: Upload mitmdump output
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: proxytest_mitmdump
           path: scripts-dev/proxy-test/out/mitmdump_out

--- a/.github/workflows/docker_push.yml
+++ b/.github/workflows/docker_push.yml
@@ -16,26 +16,26 @@ jobs:
     steps:
       - name: Set up QEMU
         id: qemu
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480 # v1
         with:
           platforms: arm64
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9 # v1
 
       - name: Inspect builder
         run: docker buildx inspect
 
       - name: Log in to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7 # v1
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
       - name: Calculate docker image tags
         id: set-tag
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: matrixdotorg/sygnal
           tags: |
@@ -46,10 +46,10 @@ jobs:
       # (part of build system config in pyproject.toml) can deduce the package version.
       # See: https://github.com/marketplace/actions/build-and-push-docker-images#path-context
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Build and push all platforms
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           push: true

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -4,14 +4,17 @@ on:
     branches: ["main"]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   check-code-style:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Poetry
-        uses: matrix-org/setup-python-poetry@v1
+        uses: matrix-org/setup-python-poetry@a82e526ebef97ec2d5000e220beb07aaadfda595 # v1
         with:
           install-project: "false"
           python-version: "3.12"
@@ -21,10 +24,10 @@ jobs:
   check-types-mypy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Poetry
-        uses: matrix-org/setup-python-poetry@v1
+        uses: matrix-org/setup-python-poetry@a82e526ebef97ec2d5000e220beb07aaadfda595 # v1
         with:
           install-project: "false"
           python-version: "3.12"
@@ -36,8 +39,8 @@ jobs:
     needs: [check-code-style, check-types-mypy]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
         with:
           python-version: "3.12"
       - run: python -m pip install -e .
@@ -48,8 +51,8 @@ jobs:
     needs: [ check-code-style, check-types-mypy ]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
         with:
           python-version: "3.8"
       - name: Patch pyproject.toml to require oldest dependencies

--- a/.github/workflows/triage_incoming.yml
+++ b/.github/workflows/triage_incoming.yml
@@ -4,12 +4,15 @@ on:
   issues:
     types: [ opened ]
 
+permissions:
+  contents: read
+
 jobs:
   add_new_issues:
     name: Add new issues to the triage board
     runs-on: ubuntu-latest
     steps:
-      - uses: octokit/graphql-action@v2.x
+      - uses: octokit/graphql-action@f7836e89a7e5bac63911bbe9653c21147b3d9bc3 # v2.x
         id: add_to_project
         with:
           headers: '{"GraphQL-Features": "projects_next_graphql"}'

--- a/.github/workflows/triage_labelled.yml
+++ b/.github/workflows/triage_labelled.yml
@@ -4,6 +4,9 @@ on:
   issues:
     types: [ labeled ]
 
+permissions:
+  contents: read
+
 jobs:
   move_needs_info:
     name: Move X-Needs-Info on the triage board
@@ -11,7 +14,7 @@ jobs:
     if: >
       contains(github.event.issue.labels.*.name, 'X-Needs-Info')
     steps:
-      - uses: actions/add-to-project@main
+      - uses: actions/add-to-project@158aad9ed186a4842abf69d0f8071a0ff95312d0 # main
         id: add_project
         with:
           project-url: "https://github.com/orgs/matrix-org/projects/67"

--- a/changelog.d/10.misc
+++ b/changelog.d/10.misc
@@ -1,0 +1,1 @@
+Run container as non-root user (uid/gid 1001) in the Docker runtime stage.

--- a/changelog.d/11.misc
+++ b/changelog.d/11.misc
@@ -1,0 +1,1 @@
+Pin all GitHub Actions to full SHA hashes; add explicit permissions blocks to all workflows.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -94,6 +94,12 @@ FROM docker.io/library/python:${PYTHON_VERSION}-slim-${DEBIAN_VERSION}
 
 COPY --from=builder /install /usr/local
 
+# Create non-root user
+RUN groupadd --system --gid 1001 sygnal \
+  && useradd --system --uid 1001 --gid 1001 sygnal
+
+USER sygnal
+
 EXPOSE 6000/tcp
 
 ENTRYPOINT ["python", "-m", "sygnal.sygnal"]

--- a/scripts-dev/proxy-test/sygnal-with-curl.Dockerfile
+++ b/scripts-dev/proxy-test/sygnal-with-curl.Dockerfile
@@ -1,4 +1,6 @@
 FROM localhost/sygnal
 
 # add curl as we use it for our testing
+USER root
 RUN apt-get update -yqq && apt-get install curl -yqq && rm -rf /var/lib/apt/lists/*
+USER sygnal

--- a/scripts-dev/proxy-test/sygnal.yaml
+++ b/scripts-dev/proxy-test/sygnal.yaml
@@ -22,7 +22,7 @@ log:
       file:
         class: "logging.handlers.WatchedFileHandler"
         formatter: "normal"
-        filename: "./sygnal.log"
+        filename: "/tmp/sygnal.log"
     loggers:
       sygnal.access:
         propagate: false


### PR DESCRIPTION
Pin all mutable action tags (`@version`) to full commit SHAs for supply-chain hardening (prevents tag-mutable injection attacks). Also add explicit `permissions:` blocks with least-privilege access to all workflows.

Closes pangeachat/security#52.