### PR TITLE
ci: add unified TO TEST enforcement caller

### DIFF
--- a/.github/workflows/issue_to_test_check.yaml
+++ b/.github/workflows/issue_to_test_check.yaml
@@ -1,0 +1,11 @@
+name: Issue TO TEST enforcement
+
+on:
+  issues:
+    types: [opened, edited, closed]
+
+jobs:
+  process:
+    uses: pangeachat/.github/.github/workflows/reusable-issue-to-test-check.yaml@main
+    permissions:
+      issues: write

--- a/.github/workflows/issue_to_test_check.yaml
+++ b/.github/workflows/issue_to_test_check.yaml
@@ -6,6 +6,6 @@ on:
 
 jobs:
   process:
-    uses: pangeachat/.github/.github/workflows/reusable-issue-to-test-check.yaml@main
+    uses: pangeachat/.github/.github/workflows/reusable-issue-to-test-check.yaml@b147c12a80922a768e52953050b9eecf3b924099 # main
     permissions:
       issues: write


### PR DESCRIPTION
## What

Add `.github/workflows/issue_to_test_check.yaml` — a thin caller of the unified reusable in [`pangeachat/.github`](https://github.com/pangeachat/.github/pull/51). Subscribes to `issues.opened` / `edited` / `closed` and delegates the policy:

- **Opened/edited**: post a one-shot reminder if the body has neither a `TO TEST` checklist nor the opt-out string `No client testing needed`.
- **Closed**: add the `needs testing` label unless the body opts out, or the close was `not_planned` / `duplicate`.

## Why

Bringing this repo under the same single-source-of-truth policy that the active service repos already use (choreographer, client, cms, pangea-bot, website). Today this repo had no automated TO TEST enforcement at all.

The `needs testing` label exists in this repo (verified before opening the PR; created where it was missing).

Depends on [pangeachat/.github #51](https://github.com/pangeachat/.github/pull/51) landing first — until then the caller fails with "workflow not found" on the first issue event.

## Testing

N/A — workflow only.

## Deploy Notes

None.