### PR TITLE
chore(qa): pin reusable TO TEST workflow to @main

### DIFF
--- a/.github/workflows/issue_to_test_check.yaml
+++ b/.github/workflows/issue_to_test_check.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   process:
-    uses: pangeachat/.github/.github/workflows/reusable-issue-to-test-check.yaml@b147c12a80922a768e52953050b9eecf3b924099 # main
+    uses: pangeachat/.github/.github/workflows/reusable-issue-to-test-check.yaml@main
     permissions:
       issues: write
     with:


### PR DESCRIPTION
## Summary

Switches the reusable TO TEST enforcement workflow reference from a pinned commit SHA to `@main`. Future tweaks to the reusable workflow (in `pangeachat/.github`) auto-propagate without bumping each caller.

## Why

We just shipped a tweak to the reminder logic in pangeachat/.github#65 and discovered each caller had to be PR'd separately to pick up the new SHA. Since these are our own org's repos calling our own reusable workflow, `@main` is the sensible pin — `.github` already requires PR review for changes there, so the trust boundary is already covered.

## Test plan

- [x] Render the workflow YAML and confirm the `uses:` line ends in `@main`
- [ ] Open a test issue with a numbered TO TEST list — confirm the new "wrong shape" message fires (i.e. the new reminder logic from #65 is now active)
