### PR TITLE
chore(qa): point issue_to_test_check at pangeachat/workflows

### DIFF
--- a/.github/workflows/issue_to_test_check.yaml
+++ b/.github/workflows/issue_to_test_check.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   process:
-    uses: pangeachat/.github/.github/workflows/reusable-issue-to-test-check.yaml@main
+    uses: pangeachat/workflows/.github/workflows/reusable-issue-to-test-check.yaml@main
     permissions:
       issues: write
     with:


### PR DESCRIPTION
## Summary

Updates the `uses:` reference for `issue_to_test_check.yaml` from `pangeachat/.github` (private) to `pangeachat/workflows` (public). Same workflow content; just a different home.

## Why

GitHub Actions does not allow public repos to call reusable workflows from private repos. The 4 public callers (`client`, `sygnal`, `synapse-pangea-chat`, `synapse-templates`) were failing instantly with zero jobs scheduled — see the trail of failed runs on `client` issues today. The fix: split the reusable workflow file out into its own dedicated public repo so every caller (public + private) can reach it.

The new repo `pangeachat/workflows` exists for this purpose. It contains only this CI script. No IP, no architecture docs (those stay in `pangeachat/.github`).

## Test plan

- [x] Workflow file content is identical (`sha256` verified during migration)
- [ ] Open a test issue and confirm the reminder fires (or doesn't, per content)
- [ ] Close the test issue and confirm `needs testing` label gets applied
