### PR TITLE
docs: per-env Firebase projects

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,7 +7,7 @@ Fork of [element-hq/sygnal](https://github.com/element-hq/sygnal). Adds visible 
 - **Our changes**: Two upstream PRs pending — [#431](https://github.com/element-hq/sygnal/pull/431) (async create fix) and [#432](https://github.com/element-hq/sygnal/pull/432) (notification content)
 - **Staging**: CI/CD via ECR + OIDC + SSM (push to `main` auto-deploys). See [deployment.instructions.md](instructions/deployment.instructions.md)
 - **Production**: Manual deploy — image built on EC2 (`localhost/pangeachat/sygnal:main`)
-- **Firebase**: Project `pangea-chat-936ee`, apps `com.talktolearn.chat` + `com.talktolearn.chat.data_message`
+- **Firebase**: Per environment — `pangea-chat-936ee` (prod), `pangea-chat-staging-analytics` (staging); apps `com.talktolearn.chat` + `com.talktolearn.chat.data_message`
 - **Config**: Managed by ansible repo (`pangeachat/ansible`), not this repo
 - **Infrastructure**: Managed by devops repo (`pangeachat/devops`) — ECR, DNS, IAM all in Terraform
 - **Legacy repo**: `pangeachat/sygnal-legacy` (archived) — old fork of matrix-org/sygnal


### PR DESCRIPTION
Staging Sygnal now pushes via pangea-chat-staging-analytics (see pangeachat/ansible#198); prod stays on pangea-chat-936ee. Doc line update only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)